### PR TITLE
on linux, close the debug log by default

### DIFF
--- a/startsmbot.sh
+++ b/startsmbot.sh
@@ -2,7 +2,8 @@
 export CONFIG_FILE=./config.json
 export SLACK_APP_TOKEN=
 export HUBOT_SLACK_TOKEN=
-export HUBOT_LOG_LEVEL=debug
+#export HUBOT_LOG_LEVEL=debug
+#export sm_servers_advantageinc_password=
 # export http_proxy=
 # export https_proxy=
 


### PR DESCRIPTION
keep the same with windows, by default, should not open the debug log
